### PR TITLE
페이지 하단으로 스크롤시 화면 상단에 헤더 고정 노출 및 UI 개선 (#3)

### DIFF
--- a/src/assets/style/app.css
+++ b/src/assets/style/app.css
@@ -4,19 +4,32 @@
 	font-family: Arial, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
 		Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 	--font-mono: 'Fira Mono', monospace;
-  --dark-color: #1c1a1a;
+	--color-white: #ffffff;
+	--color-gray-1: #323232;
+	--color-gray-2: #2d2d2d;
+	--color-gray-3: #262626;
+	--color-dark-1: #1c1a1a;
+	--color-dark-2: #171515;
+	--color-black: #000000;
 
-  --header-height: 50px;
-  --footer-height: 100px;
+	--header-height: 72px;
+	--footer-height: 100px;
+
+	--page-padding: 20px;
+	--page-max-width: 1280px;
+}
+
+* {
+	box-sizing: border-box;
 }
 
 body {
 	min-height: 100vh;
 	margin: 0;
-	background-color: var(--dark-color);
-  color: #fff;
+	background-color: var(--color-dark-2);
+	color: #fff;
 }
 
 .hidden {
-  display: none;
+	display: none;
 }

--- a/src/lib/banner/Banner.svelte
+++ b/src/lib/banner/Banner.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-    import '$assets/style/app.css';
+	import '$assets/style/app.css';
 </script>
 
 <div class="banner">
-    <h2>Banner</h2>
+	<h2>Banner</h2>
 </div>
 
 <style>
-    .banner {
-        height: 400px;
-    }
+	.banner {
+		height: 400px;
+	}
 </style>

--- a/src/lib/events/Events.svelte
+++ b/src/lib/events/Events.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-    import '$assets/style/app.css';
+	import '$assets/style/app.css';
 </script>
 
 <div class="events">
-    <h2>Events</h2>
+	<h2>Events</h2>
 </div>
 
 <style>
-    .events {
-        height: 400px;
-    }
+	.events {
+		height: 400px;
+	}
 </style>

--- a/src/lib/header/Header.svelte
+++ b/src/lib/header/Header.svelte
@@ -1,31 +1,44 @@
 <script lang="ts">
-    import logo from '$assets/images/itsuda-logo.png';
-    import '$assets/style/app.css';
+	import logo from '$assets/images/itsuda-logo.png';
+	import '$assets/style/app.css';
 </script>
 
 <header>
-    <h2 class="hidden">Header</h2>
-	<div class="corner">
-		<a href="/">
-			<img src={logo} alt="Itsuda" />
-		</a>
+	<h2 class="hidden">Header</h2>
+	<div class="inner">
+		<div class="logo">
+			<a href="/">
+				<img src={logo} alt="Itsuda" />
+			</a>
+		</div>
 	</div>
 </header>
 
 <style>
 	header {
+		position: sticky;
+		top: 0;
+		height: var(--header-height);
+		background-color: var(--color-dark-1);
+	}
+
+	.inner {
 		display: flex;
 		justify-content: space-between;
-        height: var(--header-height);
-        background-color: #3b3b3b;
+		align-items: center;
+		width: 100%;
+		max-width: var(--page-max-width);
+		height: 100%;
+		padding-inline: var(--page-padding);
+		margin: 0 auto;
 	}
 
-	.corner {
-		width: 3em;
-		height: 3em;
+	.logo {
+		width: 52px;
+		height: 52px;
 	}
 
-	.corner a {
+	.logo a {
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -33,9 +46,9 @@
 		height: 100%;
 	}
 
-	.corner img {
-		width: 2em;
-		height: 2em;
+	.logo img {
+		width: 100%;
+		height: 100%;
 		object-fit: contain;
 	}
 </style>

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Header from '$lib/header/Header.svelte';
-    import Footer from '$lib/footer/Footer.svelte';
+	import Footer from '$lib/footer/Footer.svelte';
 	import '$assets/style/app.css';
 </script>
 
@@ -16,11 +16,10 @@
 		flex: 1;
 		display: flex;
 		flex-direction: column;
-		padding: 1rem;
 		width: 100%;
-		max-width: 1024px;
-        min-height: calc(100vh - var(--header-height) - var(--footer-height));
+		max-width: var(--page-max-width);
+		min-height: calc(100vh - var(--header-height) - var(--footer-height));
+		padding-inline: var(--page-padding);
 		margin: 0 auto;
-		box-sizing: border-box;
 	}
 </style>


### PR DESCRIPTION
### 작업 내용
- 헤더 background color 변경
- 헤더 `max-width`, `padding-inline` 은 페이지 layout main과 동일하게 적용하기 위해 app.css에서 변수로 관리
- 페이지 하단으로 스크롤시 화면 상단에 헤더 고정 노출 처리
   - css sticky 속성 사용
   - IE 대응 고려 안함

### 스크린샷
![header](https://user-images.githubusercontent.com/33195744/171988882-11a954db-27a8-49b2-9bed-f52e4badb823.gif)

