### PR TITLE
[v0.0.3] 2022-06-06 Release

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "next",
 		"@sveltejs/adapter-vercel": "^1.0.0-next.47",
-		"@sveltejs/kit": "1.0.0-next.291",
+		"@sveltejs/kit": "1.0.0-next.348",
 		"@types/cookie": "^0.4.1",
 		"prettier": "^2.5.1",
 		"prettier-plugin-svelte": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,34 +1,33 @@
 {
-  "name": "itsuda-web",
-  "version": "0.0.1",
-  "scripts": {
-    "dev": "svelte-kit dev",
-    "build": "svelte-kit build",
-    "package": "svelte-kit package",
-    "preview": "svelte-kit preview",
-    "prepare": "svelte-kit sync",
-    "check": "svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
-    "lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. .",
-    "format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. ."
-  },
-  "devDependencies": {
-    "@sveltejs/adapter-auto": "next",
-    "@sveltejs/adapter-vercel": "^1.0.0-next.47",
-    "@sveltejs/kit": "next",
-    "@types/cookie": "^0.4.1",
-    "prettier": "^2.5.1",
-    "prettier-plugin-svelte": "^2.5.0",
-    "svelte": "^3.46.0",
-    "svelte-check": "^2.2.6",
-    "svelte-preprocess": "^4.10.1",
-    "tslib": "^2.3.1",
-    "typescript": "~4.6.2"
-  },
-  "type": "module",
-  "dependencies": {
-    "@fontsource/fira-mono": "^4.5.0",
-    "@lukeed/uuid": "^2.0.0",
-    "cookie": "^0.4.1"
-  }
+	"name": "itsuda-web",
+	"version": "0.0.1",
+	"scripts": {
+		"dev": "svelte-kit dev",
+		"build": "svelte-kit build",
+		"package": "svelte-kit package",
+		"preview": "svelte-kit preview",
+		"check": "svelte-check --tsconfig ./tsconfig.json",
+		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
+		"lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. .",
+		"format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. ."
+	},
+	"devDependencies": {
+		"@sveltejs/adapter-auto": "next",
+		"@sveltejs/adapter-vercel": "^1.0.0-next.47",
+		"@sveltejs/kit": "1.0.0-next.291",
+		"@types/cookie": "^0.4.1",
+		"prettier": "^2.5.1",
+		"prettier-plugin-svelte": "^2.5.0",
+		"svelte": "^3.46.0",
+		"svelte-check": "^2.2.6",
+		"svelte-preprocess": "^4.10.1",
+		"tslib": "^2.3.1",
+		"typescript": "~4.6.2"
+	},
+	"type": "module",
+	"dependencies": {
+		"@fontsource/fira-mono": "^4.5.0",
+		"@lukeed/uuid": "^2.0.0",
+		"cookie": "^0.4.1"
+	}
 }

--- a/src/app.html
+++ b/src/app.html
@@ -3,11 +3,11 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="description" content="Svelte demo app" />
-		<link rel="icon" href="%svelte.assets%/favicon.png" />
+		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		%svelte.head%
+		%sveltekit.head%
 	</head>
 	<body>
-		<div>%svelte.body%</div>
+		<div>%sveltekit.body%</div>
 	</body>
 </html>


### PR DESCRIPTION
### 개요
- vercel 배포 실패 원인 파악 및 수정

### 상세
- vercel 설정 Node 버전 14.x -> 16.x 로 수정
   <img width="992" alt="Screen Shot 2022-06-06 at 1 16 35 PM" src="https://user-images.githubusercontent.com/33195744/172093903-be78a741-2d71-442a-bce4-c5a22a8dea1b.png">
   <img width="1038" alt="Screen Shot 2022-06-06 at 1 15 29 PM" src="https://user-images.githubusercontent.com/33195744/172093835-1d41b30e-6d79-4abb-89b6-9ef565150a04.png">
- sveltejs/kit version 수정
   <img width="972" alt="Screen Shot 2022-06-06 at 1 21 45 PM" src="https://user-images.githubusercontent.com/33195744/172094395-482e7a08-550d-4077-acc7-f3ac3ba39441.png">
- `%svelte.assets%` -> `%sveltekit.assets%` 와 같이 변경 (최근 sveltekit 설정이 변경됨)
   <img width="977" alt="Screen Shot 2022-06-06 at 1 12 12 PM" src="https://user-images.githubusercontent.com/33195744/172093488-4f2f4a7a-e63a-4857-b22c-059cd589dc12.png">
 