### PR TITLE
hotfix: header z-index 지정

### DIFF
--- a/src/lib/header/Header.svelte
+++ b/src/lib/header/Header.svelte
@@ -20,6 +20,7 @@
 		height: var(--header-height);
 		background-color: var(--color-dark-1);
 		border-bottom: 1px solid var(--color-gray-2);
+		z-index: 1;
 
 		.logo {
 			width: 52px;


### PR DESCRIPTION
### 이슈
- 화면 스크롤을 아래로 내리면 배너 `.box` 영역이 헤더 위로 올라옴

### 작업 내용
- `header` style `z-index` 속성 지정

### 스크린샷
AS-IS|TO-BE
---|---
<img width="397" alt="Screen Shot 2022-06-26 at 7 01 54 PM" src="https://user-images.githubusercontent.com/33195744/175809126-4582b2d1-4efa-489e-8466-b88f3ac4dc09.png">|<img width="384" alt="Screen Shot 2022-06-26 at 7 02 02 PM" src="https://user-images.githubusercontent.com/33195744/175809130-2168db19-f47d-4431-90ed-870a54e2f418.png">

