### PR TITLE
이벤트 캘린더 와이어 프레임 UI 추가

### DIFF
--- a/src/assets/style/app.scss
+++ b/src/assets/style/app.scss
@@ -14,6 +14,8 @@
 	--color-dark-1: #1c1a1a;
 	--color-dark-2: #171515;
 	--color-black: #000000;
+	--color-red: #ff3e00;
+	--color-blue: #3178c6;
 
 	--header-height: 72px;
 	--footer-height: 100px;

--- a/src/lib/calendar/Calendar.svelte
+++ b/src/lib/calendar/Calendar.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	const days = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+	const monthlyDateLength = 31;
+	const columLength = days.length;
+	const rowLength = Math.ceil(monthlyDateLength / columLength);
+	console.log(columLength, rowLength)
+</script>
+
+<table class="calendar">
+	<thead>
+		<tr>
+			{#each days as day}
+				<th>{day}</th>
+			{/each}
+		</tr>
+	</thead>
+	<tbody>
+		{#each Array(rowLength) as _}
+			<tr>
+				{#each Array(columLength) as _}
+				<td></td>
+				{/each}
+			</tr>
+		{/each}
+	</tbody>
+</table>
+
+<style lang="scss" scoped>
+	table.calendar {
+		width: 100%;
+		border-collapse: collapse;
+		border-radius: 15px;
+		border-style: hidden;
+		box-shadow: 0 0 0 1px var(--color-gray-2);
+		overflow: hidden;
+
+		th, td {
+			border: 1px solid var(--color-gray-2);
+			width: calc(100% / 7);
+		}
+
+		th {
+			font-size: 12px;
+			font-weight: 400;
+			padding: 6px 0;
+			background-color: var(--color-gray-3);
+
+			&:first-child {
+				color: var(--color-red);
+			}
+
+			&:last-child {
+				color: var(--color-blue);
+			}
+		}
+
+		td {
+			height: 150px;
+			padding: 10px 0;
+			background-color: var(--color-dark-2);
+		}
+	}
+</style>

--- a/src/lib/events/Events.svelte
+++ b/src/lib/events/Events.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
+	import Calendar from '$lib/calendar/Calendar.svelte';
 </script>
 
 <div class="events">
 	<h2>Events</h2>
+	<Calendar />
 </div>
 
 <style>
 	.events {
-		height: 400px;
 	}
 </style>

--- a/src/lib/footer/Footer.svelte
+++ b/src/lib/footer/Footer.svelte
@@ -28,6 +28,7 @@
 		background-color: var(--color-dark-1);
 		color: var(--color-lightgray-2);
 		font-size: 14px;
+		margin-bottom: 70px;
 
 		.inner {
 			.contents {

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -20,6 +20,6 @@
 		max-width: var(--page-max-width);
 		min-height: calc(100vh - var(--header-height) - var(--footer-height));
 		padding-inline: var(--page-padding);
-		margin: 0 auto;
+		margin: 0 auto 100px;
 	}
 </style>


### PR DESCRIPTION
#5 

### 작업 내용
- `color` variables 추가
   - `--color-red` : svelte color code 에서 가져옴
   - `--color-blue` : typescript color code 에서 가져옴
- 이벤트 캘린더 와이어 프레임 UI 추가
   - `src/lib/calendar/Calendar.svelte` 파일 생성, UI 구조만 잡아놓은 상태.
   - 스벨트에서 배열을 순회할 경우 `{#each days as day}` 와 같이 작성하고 단순 number 형태로 몇 번 반복할지만 알고 있을 경우에는 `{#each Array(rowLength) as _}` 와 같이 구현할 수 있음.
- footer 상하 여백 추가

### 스크린샷
<img width="1549" alt="Screen Shot 2022-10-27 at 11 37 28 PM" src="https://user-images.githubusercontent.com/33195744/198319682-51b6a25c-fbd1-4acf-9718-2f11db2c1cdb.png">
